### PR TITLE
feat(permissions): remove deprecated `PushPermissionState`

### DIFF
--- a/libs/permissions/src/utils/permissions-predicates.ts
+++ b/libs/permissions/src/utils/permissions-predicates.ts
@@ -1,19 +1,19 @@
 export function isGranted(
-    state: PermissionState | NotificationPermission | PushPermissionState,
+    state: NotificationPermission | PermissionState,
 ): state is 'granted' {
     return state === 'granted';
 }
 
 export function isDenied(
-    state: PermissionState | NotificationPermission | PushPermissionState,
+    state: NotificationPermission | PermissionState,
 ): state is 'denied' {
     return state === 'denied';
 }
 
 export function isPrompt(s: NotificationPermission): s is 'default';
-export function isPrompt(s: PermissionState | PushPermissionState): s is 'prompt';
+export function isPrompt(s: PermissionState): s is 'prompt';
 export function isPrompt(
-    state: PermissionState | NotificationPermission | PushPermissionState,
+    state: PermissionState | NotificationPermission,
 ): state is 'prompt' | 'default' {
     return state === 'prompt' || state === 'default';
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes #260

PushPermissionState is equal PermissionState

<img width="711" alt="image" src="https://github.com/taiga-family/ng-web-apis/assets/12021443/9caf8b20-453c-40f2-97c8-2ebb953e0c9d">
