### PR TITLE
feat(platform): add browser parser

### DIFF
--- a/libs/platform/src/index.ts
+++ b/libs/platform/src/index.ts
@@ -11,3 +11,4 @@ export * from './utils/is-edge';
 export * from './utils/is-firefox';
 export * from './utils/is-ios';
 export * from './utils/is-safari';
+export * from './utils/parse-browser';

--- a/libs/platform/src/tests/parse-browser.spec.ts
+++ b/libs/platform/src/tests/parse-browser.spec.ts
@@ -1,0 +1,122 @@
+// cspell:ignore CriOS FxiOS EdgiOS EdgA Trident
+
+import {parseBrowser} from '@ng-web-apis/platform';
+
+describe('parseBrowser', () => {
+    it('parses Chrome', () => {
+        const userAgent =
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'chrome',
+            version: '140.0.0.0',
+        });
+    });
+
+    it('parses Chrome on iOS', () => {
+        const userAgent =
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/140.0.7339.53 Mobile/15E148 Safari/604.1';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'chrome',
+            version: '140.0.7339.53',
+        });
+    });
+
+    it('parses Edge', () => {
+        const userAgent =
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.3485.81';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'edge',
+            version: '140.0.3485.81',
+        });
+    });
+
+    it('parses Edge on iOS', () => {
+        const userAgent =
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/140.0.3485.81 Mobile/15E148 Safari/605.1.15';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'edge',
+            version: '140.0.3485.81',
+        });
+    });
+
+    it('parses Edge on Android', () => {
+        const userAgent =
+            'Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36 EdgA/140.0.3485.81';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'edge',
+            version: '140.0.3485.81',
+        });
+    });
+
+    it('parses Firefox', () => {
+        const userAgent =
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:142.0) Gecko/20100101 Firefox/142.0';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'firefox',
+            version: '142.0',
+        });
+    });
+
+    it('parses Firefox on iOS', () => {
+        const userAgent =
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/142.0 Mobile/15E148 Safari/605.1.15';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'firefox',
+            version: '142.0',
+        });
+    });
+
+    it('parses Safari', () => {
+        const userAgent =
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'safari',
+            version: '18.6',
+        });
+    });
+
+    it('parses Safari on iOS', () => {
+        const userAgent =
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'safari',
+            version: '18.6',
+        });
+    });
+
+    it('parses Internet Explorer 11', () => {
+        const userAgent =
+            'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'internet-explorer',
+            version: '11.0',
+        });
+    });
+
+    it('parses Internet Explorer 10', () => {
+        const userAgent =
+            'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)';
+
+        expect(parseBrowser(userAgent)).toEqual({
+            name: 'internet-explorer',
+            version: '10.0',
+        });
+    });
+
+    it('returns unknown browser', () => {
+        expect(parseBrowser('curl/8.7.1')).toEqual({
+            name: 'unknown',
+            version: null,
+        });
+    });
+});

--- a/libs/platform/src/utils/parse-browser.ts
+++ b/libs/platform/src/utils/parse-browser.ts
@@ -1,0 +1,61 @@
+// cspell:ignore EdgA EdgiOS FxiOS CriOS Trident
+
+export type BrowserName =
+    | 'chrome'
+    | 'edge'
+    | 'firefox'
+    | 'internet-explorer'
+    | 'safari'
+    | 'unknown';
+
+export interface BrowserInfo {
+    readonly name: BrowserName;
+    readonly version: string | null;
+}
+
+interface BrowserPattern {
+    readonly name: Exclude<BrowserName, 'unknown'>;
+    readonly pattern: RegExp;
+    readonly version: RegExp;
+}
+
+const BROWSERS: readonly BrowserPattern[] = [
+    {
+        name: 'edge',
+        pattern: /(?:EdgA|EdgiOS|Edg)\//,
+        version: /(?:EdgA|EdgiOS|Edg)\/([\d.]+)/,
+    },
+    {
+        name: 'firefox',
+        pattern: /(?:Firefox|FxiOS)\//,
+        version: /(?:Firefox|FxiOS)\/([\d.]+)/,
+    },
+    {
+        name: 'chrome',
+        pattern: /(?:Chrome|CriOS)\//,
+        version: /(?:Chrome|CriOS)\/([\d.]+)/,
+    },
+    {
+        name: 'safari',
+        pattern: /Safari\//,
+        version: /Version\/([\d.]+)/,
+    },
+    {
+        name: 'internet-explorer',
+        pattern: /(?:MSIE |Trident\/)/,
+        version: /(?:MSIE |rv:)([\d.]+)/,
+    },
+];
+
+export function parseBrowser(userAgent: string): BrowserInfo {
+    const browser = BROWSERS.find(({pattern}) => pattern.test(userAgent));
+
+    if (!browser) {
+        return {name: 'unknown', version: null};
+    }
+
+    return {
+        name: browser.name,
+        version: browser.version.exec(userAgent)?.[1] ?? null,
+    };
+}


### PR DESCRIPTION
## Motivation

Applications often need to parse a user agent to display browser information such as its name and version.

Currently this logic has to be implemented separately in consuming projects.

## Changes

* add `parseBrowser(userAgent)` utility to `@ng-web-apis/platform`
* add `BrowserInfo` and `BrowserName` types
* support:

  * Chrome / Chrome on iOS
  * Edge / Edge on iOS / Android
  * Firefox / Firefox on iOS
  * Safari
  * Internet Explorer
  * unknown user agents
* add tests for supported user agent variants

## Example

```ts
import {parseBrowser} from '@ng-web-apis/platform';

parseBrowser(navigator.userAgent);
// {name: 'chrome', version: '140.0.0.0'}
```

This allows projects to reuse browser parsing logic instead of maintaining their own implementation.
